### PR TITLE
Add missing metadata endpoint

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -129,6 +129,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->booleanNode('smart_crop')->end()
+                            ->booleanNode('metadata_only')->end()
                             ->arrayNode('filters')
                                 ->prototype('array')
                                     ->children()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -87,6 +87,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             array(array('valign'=>'middle'), array('valign'=>'middle')),
             array(array('valign'=>'bottom'), array('valign'=>'bottom')),
             array(array('smart_crop'=>true), array('smart_crop'=>true)),
+            array(array('metadata_only'=>true), array('metadata_only'=>true)),
             array(
                 array('filters'=>array( array('name'=>'brightness', 'arguments'=>array('82')) )),
                 array('filters'=>array( array('name'=>'brightness', 'arguments'=>array('82')) )),

--- a/Transformer/BaseTransformer.php
+++ b/Transformer/BaseTransformer.php
@@ -25,6 +25,7 @@ class BaseTransformer
         'halign' => 'halign',
         'valign' => 'valign',
         'smart_crop' => 'smartCrop',
+        'metadata_only' => 'metadataOnly',
         'filters' => 'filters'
     );
 
@@ -186,6 +187,19 @@ class BaseTransformer
     protected function smartCrop(Builder $url, $args)
     {
         $url->smartCrop($args);
+    }
+
+    /**
+     * Request metadata endpoint
+     *
+     * @param \Thumbor\Url\Builder $url
+     * @param array $args
+     *
+     * @return void
+     */
+    protected function metadataOnly(Builder $url, $args)
+    {
+        $url->metadataOnly($args);
     }
 
     /**


### PR DESCRIPTION
Thumbor can respond to a metadata endpoint, but the option to create it seems to be missing from PhumborBundle. 

This seems to add it and it seems to work locally, however I don't actually know what I'm doing :grin:

Haven't run tests yet.
