### PR TITLE
Widen installable versions of 99designs/phumbor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/jbouzekri/PhumborBundle",
     "license": "MIT",
     "require": {
-        "99designs/phumbor": "1.1.x"
+        "99designs/phumbor": "^1.1"
     },
     "require-dev": {
         "symfony/config": "~2.4",


### PR DESCRIPTION
This PR widens the installable versions of `99designs/phumbor`.

There is a newer [`v1.2.0` release](https://github.com/99designs/phumbor/releases/tag/1.2.0) that can't currently be installed alongside this bundle.