### PR TITLE
Still getting error on 1.2.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ namespace Jb\Bundle\PhumborBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-
+use Symfony\Component\HttpKernel\Kernel;
 /**
  * PhumborBundle configuration structure.
  *

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\HttpKernel\Kernel;
+
 /**
  * PhumborBundle configuration structure.
  *


### PR DESCRIPTION
!!  Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Kernel" from namespace "Jb\Bundle\PhumborBundle\DependencyInjection".
