### PR TITLE
Use webfactory/phumbor instead of 99designs/phumbor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/jbouzekri/PhumborBundle",
     "license": "MIT",
     "require": {
-        "99designs/phumbor": "^1.1"
+        "webfactory/phumbor": "^1.1"
     },
     "require-dev": {
         "symfony/config": "~2.4",


### PR DESCRIPTION
The `99designs/phumbor` library has been unmaintained for a long time. In particular, there is a long-standing issue regarding application of `rawurlencode()` to image URLs (https://github.com/99designs/phumbor/issues/20) which has not been addressed. Also the [direct question whether the code is still maintained or not](https://github.com/99designs/phumbor/issues/30) has not been answered for almost a year.

In order to address the URL encoding issue, I forked the original repo:

* https://github.com/webfactory/phumbor/
* https://packagist.org/packages/webfactory/phumbor

With this change I would like to suggest switching this bundle over to the forked library.