### PR TITLE
Add classname-based service ids to simplify autowiring

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,21 +4,31 @@ parameters:
     phumbor.twig.extension.class: Jb\Bundle\PhumborBundle\Twig\PhumborExtension
 
 services:
-    phumbor.url.builder_factory:
+    Thumbor\Url\BuilderFactory:
         class: '%phumbor.url.builder_factory.class%'
         arguments:
             - '%phumbor.server.url%'
             - '%phumbor.secret%'
 
-    phumbor.url.transformer:
+    Jb\Bundle\PhumborBundle\Transformer\BaseTransformer:
         class: '%phumbor.url.transformer.class%'
         arguments:
-            - '@phumbor.url.builder_factory'
+            - '@Thumbor\Url\BuilderFactory'
             - '%phumbor.transformations%'
 
-    phumbor.twig.extension:
+    Jb\Bundle\PhumborBundle\Twig\PhumborExtension:
         class: '%phumbor.twig.extension.class%'
         arguments:
-            - '@phumbor.url.transformer'
+            - '@Jb\Bundle\PhumborBundle\Transformer\BaseTransformer'
         tags:
             - { name: twig.extension }
+
+    # Service aliases for BC:
+    phumbor.url.builder_factory:
+        alias: Thumbor\Url\BuilderFactory
+
+    phumbor.url.transformer:
+        alias: Jb\Bundle\PhumborBundle\Transformer\BaseTransformer
+
+    phumbor.twig.extension:
+        alias: Jb\Bundle\PhumborBundle\Twig\PhumborExtension


### PR DESCRIPTION
This should make it possibly for users to use autoloading, but still be BC.

Note that in newer Symfony versions (4.x?) services will be private by default, so services from this bundle cannot be looked up at runtime any may be removed when the container is optimized. However, I think we should not start making things public here.


