### PR TITLE
Allow overriding transformation definitions in later config files

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,7 +64,9 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('transformations')
-                    ->prototype('array')
+                    ->useAttributeAsKey('id')
+                    ->arrayPrototype()
+                        ->performNoDeepMerging()
                         // Filter key is a prototype array. Remove it if empty array
                         ->validate()
                             ->always(function ($val) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -45,6 +45,41 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($config['server']['secret'], '123456789');
     }
 
+    public function testTransformationMerging()
+    {
+        // When a transformation is re-defined (overridden) in a later config file,
+        // the newer definition entirely replaces the older one.
+
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(), array(
+            // Values from first config file
+            array(
+                'transformations' => array(
+                    'test_not_overridden' => array(
+                        'resize' => array('width' => 100, 'height' => 100),
+                    ),
+                    'test_overridden' => array(
+                        'filters' => array(array('name' => 'quality', 'arguments' => array(60))),
+                        'resize' => array('width' => 100, 'height' => 100),
+                    ),
+                )
+            ),
+            // Values from second config file, should win
+            array(
+                'transformations' => array(
+                    'test_overridden' => array(
+                        'resize' => array('width' => 200, 'height' => 200),
+                    ),
+                )
+            ),
+        ));
+
+        $this->assertEquals(array(
+            'test_overridden' => array('resize' => array('width'=>200, 'height'=>200)),
+            'test_not_overridden' => array('resize' => array('width'=>100, 'height'=>100)),
+        ), $config['transformations']);
+    }
+
     /**
      * @dataProvider getTransformationData
      */


### PR DESCRIPTION
When transformations are re-defined/overridden by their name in later config files, the later definition should completely replace the first one. Here's an example:

```yml
# config.yml

jb_phumbor:
    transformations:
        test_overridden:
            filters:
                - { name: 'quality', arguments: [ 60 ] }
            resize: { width: 100, height: 100 }
        test_not_overridden:
            resize: { width: 100, height: 100 }
```

```yml
# config_development.yml

imports:
    - { resource: config.yml }

jb_phumbor:
    transformations:
        test_overridden:
            resize: { width: 200, height: 200 }
```

... then the resulting config should have `test_not_overridden` as provided, and `test_overridden` consist of the "resize" operation (200x200) only.
