### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,8 +21,8 @@ jobs:
                 with:
                   php-version: ${{ env.PHP_VERSION }}
                   tools: composer:v2
-            -   uses: actions/checkout@v3
-            -   uses: actions/cache@v2
+            -   uses: actions/checkout@v4
+            -   uses: actions/cache@v4
                 with:
                     path: vendor
                     key: composer-${{ runner.os }}-${{ env.PHP_VERSION }}-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ jobs:
                 with:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
             -   run: VERSION=${{ matrix.symfony-locked-version }} .github/workflows/lock-symfony-version.sh
                 if: matrix.symfony-locked-version != 'none'
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v4
                 with:
                     path: vendor
                     key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.symfony-locked-version }}-${{ matrix.dependency-version }}-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
                     - { php-version: 8.1, symfony-locked-version: 6.4.*, dependency-version: prefer-stable }
                     - { php-version: 8.2, symfony-locked-version: 7.0.*, dependency-version: prefer-stable }
                     - { php-version: 8.3, symfony-locked-version: 7.0.*, dependency-version: prefer-stable }
+                    - { php-version: 8.4, symfony-locked-version: 7.0.*, dependency-version: prefer-stable }
         name: PHPUnit (PHP ${{matrix.php-version}}, Symfony Version Lock ${{ matrix.symfony-locked-version }}, ${{ matrix.dependency-version }})
         steps:
             -   uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/jbouzekri/PhumborBundle",
     "license": "MIT",
     "require": {
-        "php": "^7.2|8.0.*|8.1.*|8.2.*|8.3.*",
+        "php": "^7.2|8.0.*|8.1.*|8.2.*|8.3.*|8.4.*",
         "symfony/config": "^3.4|^4.4|^5.0|^6.0|^7.0",
         "symfony/dependency-injection": "^3.4|^4.4|^5.0|^6.0|^7.0",
         "symfony/http-kernel": "^3.4|^4.4|^5.0|^6.0|^7.0",

--- a/src/DependencyInjection/JbPhumborExtension.php
+++ b/src/DependencyInjection/JbPhumborExtension.php
@@ -3,8 +3,8 @@
 namespace Jb\Bundle\PhumborBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 
 /**


### PR DESCRIPTION
Using PHP 8.4 for quite some time locally with this extension, and it works just fine. The only thing I adjusted in here is the namespace for the `Extension` class, as the previously one is marked as `internal` since symfony `7.1`.