### PR TITLE
Use short array notation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -117,7 +117,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('halign')
                                 ->validate()
-                                    ->ifNotInArray(array('left', 'center', 'right'))
+                                    ->ifNotInArray(['left', 'center', 'right'])
                                     ->thenInvalid(
                                         'Invalid transformation.halign value %s. '
                                         . 'It must be one of the following : left, center, right.'
@@ -126,7 +126,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('valign')
                                 ->validate()
-                                    ->ifNotInArray(array('top', 'middle', 'bottom'))
+                                    ->ifNotInArray(['top', 'middle', 'bottom'])
                                     ->thenInvalid(
                                         'Invalid transformation.valign value %s. '
                                         . 'It must be one of the following : top, middle, bottom.'

--- a/src/Transformer/BaseTransformer.php
+++ b/src/Transformer/BaseTransformer.php
@@ -17,7 +17,7 @@ class BaseTransformer
      *
      * @var array
      */
-    protected static $filterMethod = array(
+    protected static $filterMethod = [
         'trim' => 'trim',
         'crop' => 'crop',
         'fit_in' => 'fitIn',
@@ -28,7 +28,7 @@ class BaseTransformer
         'smart_crop' => 'smartCrop',
         'metadata_only' => 'metadataOnly',
         'filters' => 'filters'
-    );
+    ];
 
     /**
      * Phumbor Builder Factory
@@ -222,9 +222,9 @@ class BaseTransformer
     protected function filters(Builder $url, $args)
     {
         foreach ($args as $arg) {
-            $arguments = (is_array($arg['arguments'])) ? $arg['arguments'] : array($arg['arguments']);
+            $arguments = (is_array($arg['arguments'])) ? $arg['arguments'] : [$arg['arguments']];
             array_unshift($arguments, $arg['name']);
-            call_user_func_array(array($url, 'addFilter'), $arguments);
+            call_user_func_array([$url, 'addFilter'], $arguments);
         }
     }
 

--- a/src/Twig/PhumborExtension.php
+++ b/src/Twig/PhumborExtension.php
@@ -34,9 +34,9 @@ class PhumborExtension extends AbstractExtension
      */
     public function getFilters(): array
     {
-        return array(
-            new TwigFilter('thumbor', array($this, 'transform')),
-        );
+        return [
+            new TwigFilter('thumbor', [$this, 'transform']),
+        ];
     }
 
     /**
@@ -44,9 +44,9 @@ class PhumborExtension extends AbstractExtension
      */
     public function getFunctions(): array
     {
-        return array(
-            new TwigFunction('thumbor', array($this, 'transform')),
-        );
+        return [
+            new TwigFunction('thumbor', [$this, 'transform']),
+        ];
     }
 
     /**
@@ -58,7 +58,7 @@ class PhumborExtension extends AbstractExtension
      *
      * @return string
      */
-    public function transform($orig, $transformation = null, $overrides = array())
+    public function transform($orig, $transformation = null, $overrides = [])
     {
         return $this->transformer->transform($orig, $transformation, $overrides);
     }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -21,7 +21,7 @@ class ConfigurationTest extends TestCase
     public function testDefaultConfig(): void
     {
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), array());
+        $config = $processor->processConfiguration(new Configuration(), []);
 
         $this->assertEquals(
             self::getBundleDefaultConfig(),
@@ -35,14 +35,14 @@ class ConfigurationTest extends TestCase
     public function testServerConfiguration(): void
     {
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), array(
-            array(
-                'server' => array(
+        $config = $processor->processConfiguration(new Configuration(), [
+            [
+                'server' => [
                     'url' => 'http://jb.phumbor.fr:8888',
                     'secret' => '123456789'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
         $this->assertEquals($config['server']['url'], 'http://jb.phumbor.fr:8888');
         $this->assertEquals($config['server']['secret'], '123456789');
@@ -54,85 +54,85 @@ class ConfigurationTest extends TestCase
         // the newer definition entirely replaces the older one.
 
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), array(
+        $config = $processor->processConfiguration(new Configuration(), [
             // Values from first config file
-            array(
-                'transformations' => array(
-                    'test_not_overridden' => array(
-                        'resize' => array('width' => 100, 'height' => 100),
-                    ),
-                    'test_overridden' => array(
-                        'filters' => array(array('name' => 'quality', 'arguments' => array(60))),
-                        'resize' => array('width' => 100, 'height' => 100),
-                    ),
-                )
-            ),
+            [
+                'transformations' => [
+                    'test_not_overridden' => [
+                        'resize' => ['width' => 100, 'height' => 100],
+                    ],
+                    'test_overridden' => [
+                        'filters' => [['name' => 'quality', 'arguments' => [60]]],
+                        'resize' => ['width' => 100, 'height' => 100],
+                    ],
+                ]
+            ],
             // Values from second config file, should win
-            array(
-                'transformations' => array(
-                    'test_overridden' => array(
-                        'resize' => array('width' => 200, 'height' => 200),
-                    ),
-                )
-            ),
-        ));
+            [
+                'transformations' => [
+                    'test_overridden' => [
+                        'resize' => ['width' => 200, 'height' => 200],
+                    ],
+                ]
+            ],
+        ]);
 
-        $this->assertEquals(array(
-            'test_overridden' => array('resize' => array('width'=>200, 'height'=>200)),
-            'test_not_overridden' => array('resize' => array('width'=>100, 'height'=>100)),
-        ), $config['transformations']);
+        $this->assertEquals([
+            'test_overridden' => ['resize' => ['width'=>200, 'height'=>200]],
+            'test_not_overridden' => ['resize' => ['width'=>100, 'height'=>100]],
+        ], $config['transformations']);
     }
 
     #[DataProvider('getTransformationData')]
     public function testTransformationConfiguration($transformationConfig, $processedTransformation): void
     {
         $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), array(
-            array(
-                'transformations' => array(
+        $config = $processor->processConfiguration(new Configuration(), [
+            [
+                'transformations' => [
                     'key' => $transformationConfig
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
         $this->assertEquals($config['transformations']['key'], $processedTransformation);
     }
 
     public static function getTransformationData(): array
     {
-        return array(
-            array(array('fit_in'=>array('width'=>10,'height'=>20)), array('fit_in'=>array('width'=>10,'height'=>20))),
-            array(
-                array('full_fit_in'=>array('width'=>10,'height'=>20)),
-                array('full_fit_in'=>array('width'=>10,'height'=>20))
-            ),
-            array(array('trim'=>true), array('trim'=>true)),
-            array(array('trim'=>'string'), array('trim'=>'string')),
-            array(
-                array('crop'=>array('top_left_x'=>10,'top_left_y'=>10,'bottom_right_x'=>10,'bottom_right_y'=>10)),
-                array('crop'=>array('top_left_x'=>10,'top_left_y'=>10,'bottom_right_x'=>10,'bottom_right_y'=>10))
-            ),
-            array(
-                array('resize'=>array('width'=>'orig','height'=>'orig')),
-                array('resize'=>array('width'=>'orig','height'=>'orig'))
-            ),
-            array(
-                array('resize'=>array('width'=>10,'height'=>10)),
-                array('resize'=>array('width'=>10,'height'=>10))
-            ),
-            array(array('halign'=>'left'), array('halign'=>'left')),
-            array(array('halign'=>'center'), array('halign'=>'center')),
-            array(array('halign'=>'right'), array('halign'=>'right')),
-            array(array('valign'=>'top'), array('valign'=>'top')),
-            array(array('valign'=>'middle'), array('valign'=>'middle')),
-            array(array('valign'=>'bottom'), array('valign'=>'bottom')),
-            array(array('smart_crop'=>true), array('smart_crop'=>true)),
-            array(array('metadata_only'=>true), array('metadata_only'=>true)),
-            array(
-                array('filters'=>array( array('name'=>'brightness', 'arguments'=>array('82')) )),
-                array('filters'=>array( array('name'=>'brightness', 'arguments'=>array('82')) )),
-            ),
-        );
+        return [
+            [['fit_in'=>['width'=>10,'height'=>20]], ['fit_in'=>['width'=>10,'height'=>20]]],
+            [
+                ['full_fit_in'=>['width'=>10,'height'=>20]],
+                ['full_fit_in'=>['width'=>10,'height'=>20]]
+            ],
+            [['trim'=>true], ['trim'=>true]],
+            [['trim'=>'string'], ['trim'=>'string']],
+            [
+                ['crop'=>['top_left_x'=>10,'top_left_y'=>10,'bottom_right_x'=>10,'bottom_right_y'=>10]],
+                ['crop'=>['top_left_x'=>10,'top_left_y'=>10,'bottom_right_x'=>10,'bottom_right_y'=>10]]
+            ],
+            [
+                ['resize'=>['width'=>'orig','height'=>'orig']],
+                ['resize'=>['width'=>'orig','height'=>'orig']]
+            ],
+            [
+                ['resize'=>['width'=>10,'height'=>10]],
+                ['resize'=>['width'=>10,'height'=>10]]
+            ],
+            [['halign'=>'left'], ['halign'=>'left']],
+            [['halign'=>'center'], ['halign'=>'center']],
+            [['halign'=>'right'], ['halign'=>'right']],
+            [['valign'=>'top'], ['valign'=>'top']],
+            [['valign'=>'middle'], ['valign'=>'middle']],
+            [['valign'=>'bottom'], ['valign'=>'bottom']],
+            [['smart_crop'=>true], ['smart_crop'=>true]],
+            [['metadata_only'=>true], ['metadata_only'=>true]],
+            [
+                ['filters'=>[ ['name'=>'brightness', 'arguments'=>['82']] ]],
+                ['filters'=>[ ['name'=>'brightness', 'arguments'=>['82']] ]],
+            ],
+        ];
     }
 
     #[DataProvider('getInvalidTypeData')]
@@ -142,27 +142,27 @@ class ConfigurationTest extends TestCase
 
         $processor = new Processor();
         $configuration = new Configuration();
-        $processor->processConfiguration($configuration, array(
-            array(
-                'transformations' => array(
+        $processor->processConfiguration($configuration, [
+            [
+                'transformations' => [
                     'key' => $transformationData
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
     }
 
     public static function getInvalidTypeData(): array
     {
-        return array(
-            array( array('resize'=>array('width'=>'toto','height'=>10)) ),
-            array( array('resize'=>array('width'=>10,'height'=>'toto')) ),
-            array( array('resize'=>array('width'=>null,'height'=>'toto')) ),
-            array( array('resize'=>array('width'=>10,'height'=>null)) ),
-            array( array('valign'=>10) ),
-            array( array('valign'=>null) ),
-            array( array('halign'=>10) ),
-            array( array('halign'=>null) ),
-        );
+        return [
+            [ ['resize'=>['width'=>'toto','height'=>10]] ],
+            [ ['resize'=>['width'=>10,'height'=>'toto']] ],
+            [ ['resize'=>['width'=>null,'height'=>'toto']] ],
+            [ ['resize'=>['width'=>10,'height'=>null]] ],
+            [ ['valign'=>10] ],
+            [ ['valign'=>null] ],
+            [ ['halign'=>10] ],
+            [ ['halign'=>null] ],
+        ];
     }
 
     /**
@@ -172,12 +172,12 @@ class ConfigurationTest extends TestCase
      */
     protected static function getBundleDefaultConfig(): array
     {
-        return array(
-            'server' => array(
+        return [
+            'server' => [
                 'url' => '%env(THUMBOR_URL)%',
                 'secret' => '%env(THUMBOR_SECURITY_KEY)%'
-            ),
-            'transformations' => array()
-        );
+            ],
+            'transformations' => []
+        ];
     }
 }

--- a/tests/DependencyInjection/JbPhumborExtensionTestCase.php
+++ b/tests/DependencyInjection/JbPhumborExtensionTestCase.php
@@ -31,7 +31,7 @@ abstract class JbPhumborExtensionTestCase extends TestCase
         $this->assertEquals($container->getParameter('phumbor.secret'), '123456789');
         $this->assertEquals(
             $container->getParameter('phumbor.transformations'),
-            array('fit_in_test' => array('fit_in' => array('width'=>100, 'height'=>80)))
+            ['fit_in_test' => ['fit_in' => ['width'=>100, 'height'=>80]]]
         );
     }
 
@@ -41,16 +41,16 @@ abstract class JbPhumborExtensionTestCase extends TestCase
      * @param array $data
      * @return \Symfony\Component\DependencyInjection\ContainerBuilder
      */
-    protected function createContainer(array $data = array()): ContainerBuilder
+    protected function createContainer(array $data = []): ContainerBuilder
     {
-        return new ContainerBuilder(new ParameterBag(array_merge(array(
-            'kernel.bundles'     => array('JbPhumborBundle' => 'Jb\\Bundle\\PhumborBundle\\JbPhumborBundle'),
+        return new ContainerBuilder(new ParameterBag(array_merge([
+            'kernel.bundles'     => ['JbPhumborBundle' => 'Jb\\Bundle\\PhumborBundle\\JbPhumborBundle'],
             'kernel.cache_dir'   => __DIR__,
             'kernel.debug'       => false,
             'kernel.environment' => 'test',
             'kernel.name'        => 'kernel',
             'kernel.root_dir'    => __DIR__,
-        ), $data)));
+        ], $data)));
     }
 
     /**
@@ -62,14 +62,14 @@ abstract class JbPhumborExtensionTestCase extends TestCase
      *
      * @return \Symfony\Component\DependencyInjection\ContainerBuilder
      */
-    protected function createContainerFromFile($file, $data = array()): ContainerBuilder
+    protected function createContainerFromFile($file, $data = []): ContainerBuilder
     {
         $container = $this->createContainer($data);
         $container->registerExtension(new JbPhumborExtension());
         $this->loadFromFile($container, $file);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->compile();
 
         return $container;

--- a/tests/Transformer/BaseTransformerTest.php
+++ b/tests/Transformer/BaseTransformerTest.php
@@ -32,11 +32,11 @@ class BaseTransformerTest extends TestCase
         $this->factory = new BuilderFactory('http://localhost', '123456789');
         $this->transformer = new BaseTransformer(
             $this->factory,
-            array(
-                'width_50' => array(
-                    'resize' => array('width'=>50, 'height'=>0)
-                )
-            )
+            [
+                'width_50' => [
+                    'resize' => ['width'=>50, 'height'=>0]
+                ]
+            ]
         );
     }
 
@@ -79,7 +79,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             'width_50',
-            array('resize' => array('width'=> 40, 'height'=>0))
+            ['resize' => ['width'=> 40, 'height'=>0]]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->resize(40, 0);
 
@@ -94,10 +94,10 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             'width_50',
-            array(
-                'resize' => array('width'=> 40, 'height'=>0),
-                'fit_in' => array('width'=> 40, 'height'=>0)
-            )
+            [
+                'resize' => ['width'=> 40, 'height'=>0],
+                'fit_in' => ['width'=> 40, 'height'=>0]
+            ]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->resize(40, 0)->fitIn(40, 0);
 
@@ -109,7 +109,7 @@ class BaseTransformerTest extends TestCase
      */
     public function testTrimWithoutColor(): void
     {
-        $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, array('trim'=>false));
+        $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, ['trim'=>false]);
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->trim(false);
 
         $this->assertEquals($transformedUrl, $buildedUrl);
@@ -120,7 +120,7 @@ class BaseTransformerTest extends TestCase
      */
     public function testTrimWithColor(): void
     {
-        $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, array('trim'=>'color'));
+        $transformedUrl = $this->transformer->transform('http://phumbor.jb.fr/logo.png', null, ['trim'=>'color']);
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->trim('color');
 
         $this->assertEquals($transformedUrl, $buildedUrl);
@@ -134,7 +134,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('crop'=> array('top_left_x'=>10, 'top_left_y'=>10, 'bottom_right_x'=>10, 'bottom_right_y'=>10))
+            ['crop'=> ['top_left_x'=>10, 'top_left_y'=>10, 'bottom_right_x'=>10, 'bottom_right_y'=>10]]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->crop(10, 10, 10, 10);
 
@@ -149,7 +149,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('resize'=> array('width'=>10, 'height'=>10))
+            ['resize'=> ['width'=>10, 'height'=>10]]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->resize(10, 10);
 
@@ -164,7 +164,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('fit_in'=> array('width'=>10, 'height'=>10))
+            ['fit_in'=> ['width'=>10, 'height'=>10]]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->fitIn(10, 10);
 
@@ -179,7 +179,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('full_fit_in'=> array('width'=>10, 'height'=>10))
+            ['full_fit_in'=> ['width'=>10, 'height'=>10]]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->fullFitIn(10, 10);
 
@@ -194,7 +194,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('halign'=> 'center')
+            ['halign'=> 'center']
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->halign('center');
 
@@ -209,7 +209,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('valign' => 'middle')
+            ['valign' => 'middle']
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->valign('middle');
 
@@ -224,7 +224,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('smart_crop' => true)
+            ['smart_crop' => true]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->smartCrop(true);
 
@@ -239,7 +239,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('metadata_only' => true)
+            ['metadata_only' => true]
         );
         $buildedUrl = $this->factory->url('http://phumbor.jb.fr/logo.png')->metadataOnly(true);
 
@@ -254,12 +254,12 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array(
-                'filters'=> array(
-                    array('name'=>'brightness', 'arguments' => 56),
-                    array('name'=>'color', 'arguments' => array('black', 'red')),
-                )
-            )
+            [
+                'filters'=> [
+                    ['name'=>'brightness', 'arguments' => 56],
+                    ['name'=>'color', 'arguments' => ['black', 'red']],
+                ]
+            ]
         );
 
         $buildedUrl = $this
@@ -283,7 +283,7 @@ class BaseTransformerTest extends TestCase
         $transformedUrl = $this->transformer->transform(
             'http://phumbor.jb.fr/logo.png',
             null,
-            array('metadata_only' => true)
+            ['metadata_only' => true]
         );
         $buildedUrl = $overrideFactory->url('http://phumbor.jb.fr/logo.png')->metadataOnly(true);
         $this->assertEquals($transformedUrl, $buildedUrl);

--- a/tests/Twig/PhumborExtensionTest.php
+++ b/tests/Twig/PhumborExtensionTest.php
@@ -32,11 +32,11 @@ class PhumborExtensionTest extends TestCase
         $this->factory = new BuilderFactory('http://localhost', '123456789');
         $transformer = new BaseTransformer(
             $this->factory,
-            array(
-                'width_50' => array(
-                    'resize' => array('width'=>50, 'height'=>0)
-                )
-            )
+            [
+                'width_50' => [
+                    'resize' => ['width'=>50, 'height'=>0]
+                ]
+            ]
         );
         $this->extension = new PhumborExtension($transformer);
     }


### PR DESCRIPTION
This change has been made by using the `LongArrayToShortArrayRector` Rector rule. (https://getrector.com/rule-detail/long-array-to-short-array-rector)